### PR TITLE
Add script to automatically assign PR reviewers

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,0 +1,15 @@
+name: Assign PR Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author
+          reviewers: Blackkirby72, connormckellips, kantab, kreklb, lmschaff, Maxwell1455, prewe5294, PistolRcks
+          max-num-of-reviewers: 2

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -14,3 +14,4 @@ jobs:
           reviewers: Blackkirby72, connormckellips, kantab, kreklb, lmschaff, Maxwell1455, prewe5294, PistolRcks
           max-num-of-reviewers: 2
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ready-comment: "Ready for review by <reviewers>"

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -13,3 +13,4 @@ jobs:
           assignees: ${{ github.actor }} # assign pull request author
           reviewers: Blackkirby72, connormckellips, kantab, kreklb, lmschaff, Maxwell1455, prewe5294, PistolRcks
           max-num-of-reviewers: 2
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
.github/workflows/assign_reviewers.yml selects two random contributors (hardcoded list) on PR openings.